### PR TITLE
Docker cleanup and misc fixes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+README.md
+.dockerignore
+Dockerfile
+docker-compose.yml

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-.env
-__pycache__
+secrets.env
+**/__pycache__
 test-file.py
 /src/cogs/TestCog.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,12 @@
 FROM python:3
+
 ENV PYTHONUNBUFFERED=1
-WORKDIR /code
+
+# Install requirements first to take advantage of docker build layer caching
+COPY ./src/requirements.txt /tmp/requirements.txt
+RUN pip install -r /tmp/requirements.txt && rm /tmp/requirements.txt
+
 COPY ./src /code
-RUN pip install -r requirements.txt
-CMD ["python", "main.py"]
+
+WORKDIR /code
+ENTRYPOINT ["python", "./main.py"]

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ $ vim secrets.env
 
 4. Edit the below environment variables:
 ```console
-DISCORD_TOKEN = ''
-TWITCH_CLIENT_ID = ''
-TWITCH_CLIENT_SECRET = ''
+DISCORD_TOKEN=
+TWITCH_CLIENT_ID=
+TWITCH_CLIENT_SECRET=
 ```
 
 5. Run docker-compose:

--- a/README.md
+++ b/README.md
@@ -1,42 +1,30 @@
 # UoY Esport Bot Rewrite
+
 ## How to set up an instance of this bot
 
-Clone this repository locally:<br/>
+1. Clone this repository:
 ```console
-$ git clone https://github.com/Ryth-cs/Esports-Bot-Rewrite.git
+$ git clone https://github.com/FragSoc/Esports-Bot-Rewrite.git
 ```
 
-Go into the directory /src:
+2. Change into the repo directory:
 ```console
-$ cd Esports-Bot-Rewrite/src/
+$ cd Esports-Bot-Rewrite
 ```
 
-Create a .env file and edit it in Vim:
+3. Create a `secrets.env` file and edit it in your favourite text editor:
 ```console
-$ vim .env
+$ vim secrets.env
 ```
 
-Edit the below environment variables:
+4. Edit the below environment variables:
 ```console
 DISCORD_TOKEN = ''
-PG_HOST = ''
-PG_DATABASE = 'esportsbot' # Edit the startup script in /db_instance if you change this
-PG_USER = 'postgres' # Edit the startup script in /db_instance if you change this
-PG_PWD = ''
+TWITCH_CLIENT_ID = ''
+TWITCH_CLIENT_SECRET = ''
 ```
 
-Move to the main directory and edit the docker-compose.yml in Vim:
-```console
-$ cd ..
-$ vim docker-compose.yml
-```
-
-Change the POSTGRES_PASSWORD to your previous value:
-```console
-POSTGRES_PASSWORD = ''
-```
-
-Exit Vim and run docker-compose:
+5. Run docker-compose:
 ```console
 $ docker-compose up
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,6 @@ services:
     image: "postgres:latest"
     environment:
       - POSTGRES_PASSWORD=Pass2020!
-    ports: 
-      - 5432:5432
     restart: unless-stopped
     volumes:
       - "db_data:/var/lib/postgresql/data"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     image: "postgres:latest"
     environment:
       - POSTGRES_PASSWORD=Pass2020!
+    ports: 
+      - 5432:5432
     restart: unless-stopped
     volumes:
       - "db_data:/var/lib/postgresql/data"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,26 +1,27 @@
 version: "3"
-   
+
 services:
   db:
     image: "postgres:latest"
     environment:
       - POSTGRES_PASSWORD=Pass2020!
-    ports: 
-      - 5432:5432
+    restart: unless-stopped
+    volumes:
+      - "db_data:/var/lib/postgresql/data"
+
   bot:
     build: .
-    command: python main.py
-    environment: 
-      - DISCORD_TOKEN=**
-      - PG_HOST=**
-      - PG_DATABASE=**
-      - PG_USER=postgres
-      - PG_PWD=Pass2020!
-      - TWITCH_CLIENT_ID=**
-      - TWITCH_CLIENT_SECRET=**
-      - ENABLE_TWITTER=False
-      - ENABLE_TWITCH=False
-    volumes:
-      - ./src/:/code
     depends_on:
       - db
+    env_file: secrets.env
+    environment:
+      - PG_HOST=db
+      - PG_DATABASE=esportsbot
+      - PG_USER=postgres
+      - PG_PWD=Pass2020!
+      - ENABLE_TWITTER=False
+      - ENABLE_TWITCH=False
+    restart: unless-stopped
+
+volumes:
+  db_data:


### PR DESCRIPTION
- Streamline docker build to take advantage of build caching for dependencies
- Update dockerignore with unneeded files
- Rewrite `docker-compose.yml`:
  - Add named volume for postgres database
  - Remove bot `src` volume since build should now be faster and this isn't needed anymore
  - Don't forward DB port as the bot can access it regardless on docker private networking
  - Hardcode connection details and credentials for the DB since the DB is no longer publicly exposed
  - Use `secrets.env` instead of `.env` for better ergonomics and understandability
  - Add `restart: unless-stopped` because it's useful :)
- Update `README.md` to reflect all above changes