### PR TITLE
Added coloredlogs to easily enable visually distinct logs

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,3 +1,6 @@
 from esportsbot import bot
+import coloredlogs
+import logging
 
+coloredlogs.install(level=logging.INFO)
 bot.launch()

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -13,3 +13,4 @@ aiohttp[speedups]
 toml
 tornado
 tweepy==3.10.0
+coloredlogs


### PR DESCRIPTION
The `coloredlogs` python module easily implements log level based colouring for the standard python logging library, which makes debugging a lot easier. A bunch of the cogs already make use of the standard logging library, but their output was not seen as logging was not enabled.